### PR TITLE
fixed undefined random weighted option

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ const createUniqueTraitsCombination = () => {
     // Randomly select a trait option
     const option = getRandomWeightedOption(filteredOptions);
     // Push selected trait option (if it has a defined value)
-    if (option.value) {
+    if (option !== undefined && option.value) {
       traits.push({
         ...(type && { type }),
         ...(display && { display }),


### PR DESCRIPTION
This bugfix aims to fix the error

> (node:22075) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'value' of undefined
>     at [...]/index.js:37:16

that occurs when there no available options, for example when using the `forbidden` key addessing ALL the traits of a Trait group

The readme states:


> For every trait in the list, each generated token will get one randomly selected option (value & image) from the options list. Except if the randomly selected option turns out to have a non-existent value, in which case the token won't get anything from that specific trait.

but the above error occurs when this situation occurs